### PR TITLE
ヘッダー、上部バーの作成（Composable 関数）

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.room.common)
+    implementation(libs.androidx.foundation)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/ts/jpc_test/MainActivity.kt
+++ b/app/src/main/java/com/ts/jpc_test/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -20,28 +21,11 @@ class MainActivity : ComponentActivity() {
         setContent {
             JPC_testTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android APP",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                    Column(modifier = Modifier.padding(innerPadding)) {
+                        StickyHeaderList()
+                    }
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    JPC_testTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/ts/jpc_test/compose.kt
+++ b/app/src/main/java/com/ts/jpc_test/compose.kt
@@ -1,0 +1,84 @@
+package com.ts.jpc_test
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+//ExperimentalFoundationApiとExperimentalMaterial3Apiを有効化し、StickyHeaderListとmaterial3を使用
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@Composable
+fun StickyHeaderList() {
+    val listState = rememberLazyListState() //スクロールを記憶
+    LazyColumn(state = listState) //スクロール可能コンポーネント
+    {
+        item {
+            TopAppBar( //上部バー
+                title = { //以下タイトルの設定
+                    Row( //横に並べる
+                        modifier = Modifier
+                            .fillMaxWidth() //幅を指定
+                            .padding(8.dp), //余白の設定
+                            verticalAlignment = Alignment.CenterVertically  // 縦方向を中央揃え
+                    ) {
+                        // 空の Spacer で左側のスペースを確保
+                        Spacer(modifier = Modifier.weight(1.5f)) //ボタンの分だけスペースを増設
+                        Text(
+                            "Todoリスト",
+                            style = MaterialTheme.typography.headlineLarge, //フォント
+                            maxLines = 1, //改行なし
+                            overflow = TextOverflow.Ellipsis //オーバーフロー（長文化)を省略
+                        )
+                        // 右端にアイコン（Spacer で中央に寄せる）
+                        Spacer(modifier = Modifier.weight(1f))
+                        IconButton(onClick = { /* 検索の処理 */ }) { //検索ボタンを追加(🚨未実装)
+                            Icon(
+                                imageVector = Icons.Filled.Search,
+                                contentDescription = "検索"
+                            )
+                        }
+                    }
+
+                }
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+        //ヘッダー　スクロールしても固定で表示される
+        stickyHeader {
+            Box( // Boxでテキストの中央揃え
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color(0xFF4A5D23)) // モスグリーン
+                    .padding(16.dp),
+                contentAlignment = Alignment.Center // Box の中央に配置
+            ) {
+                Text(
+                    text = "セクション 1",
+                    color = Color.White,
+                    textAlign = TextAlign.Center // テキストを中央揃え
+                )
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+androidx.compose.compiler.version=1.5.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.8.0"
+foundation = "1.7.8"
 kotlin = "2.0.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -12,6 +13,7 @@ roomCommon = "2.6.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "foundation" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
## 概要
stickyHeaderでヘッダーの作成。
TopAppBarでテキストとボタンを追加
学習につき、コメントを多めに記述

## 変更点
stickyHeadeでヘッダーを作成
TopAppBarでテキストとボタンを作成。ボタンの中身はなし

## 背景・目的
LazyColumn、item、Spacer、TopAppBar…他
を学習

## 影響範囲
新規立ち上げにつき、全体に影響

## 動作確認
Android studio エミュレーター（Pixel6 API33）

## 参考元
https://developer.android.com/courses/android-basics-compose/course?hl=ja.（3章）
https://developer.android.com/develop/ui/compose/phases?hl=ja
https://qiita.com/karamage/items/9b2b5a79c364b72836d4
https://qiita.com/takagimeow/items/5f9810831e01e7b8b108. (ヘッダー部分)

## 追記

## 画像
<img src="https://github.com/user-attachments/assets/314932af-9dea-4c62-8bb7-7b0431158795" width="33%">