### PR TITLE
データベースとアイテムの紐付け

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AppInsightsSettings">
+    <option name="selectedTabId" value="Android Vitals" />
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-03-11T01:28:31.074766Z">
+        <DropdownSelection timestamp="2025-03-18T04:46:51.675645Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/tsuchida/.android/avd/Pixel_6_API_33.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=16251JECB03649" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-03-18T04:46:51.675645Z">
+        <DropdownSelection timestamp="2025-03-19T00:05:27.485601Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=16251JECB03649" />

--- a/app/src/main/java/com/ts/jpc_test/Compose.kt
+++ b/app/src/main/java/com/ts/jpc_test/Compose.kt
@@ -1,5 +1,6 @@
 package com.ts.jpc_test
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -23,53 +24,63 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 // データクラス : ヘッダーのセクション情報を保持
 data class Headtitle(val title: String)
 
-// Composable関数 : メイン画面のUIを構築
+@SuppressLint("UnrememberedMutableState")
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun MainComponent(todoDao: TodoDao) {
-    val listState = rememberLazyListState()
+    val listState = rememberLazyListState()  // 修正: 統一
     val sheetState = rememberModalBottomSheetState()
     val scope = rememberCoroutineScope()
     var selectedItem by remember { mutableStateOf<Todo?>(null) }
-    val todoList by todoDao.getAll().collectAsState(initial = emptyList())
+    val todoList by todoDao.getActiveTodos().collectAsState(initial = emptyList())
     val sectionList by todoDao.getAllSections().collectAsState(initial = emptyList()) // セクションリスト取得
 
     var carentNum by remember { mutableStateOf(0) } // 選択されたセクション番号
     var showDialog by remember { mutableStateOf(false) } // ダイアログ表示状態
-    val scrollListState = rememberLazyListState()
 
-    //最初のセクションで初期値を挿入
+    // `filteredTodoList` を `derivedStateOf` で最適化
+    val filteredTodoList by derivedStateOf {
+        todoList.filter { it.sectionNum == carentNum }
+    }
+
+    // DBアクセスの最適化
     LaunchedEffect(Unit) {
         scope.launch(Dispatchers.IO) {
             val sectionId = initialAccess(todoDao) ?: return@launch
-            carentNum = sectionId // 例のセクション番号を設定
+            withContext(Dispatchers.Main) {
+                carentNum = sectionId
+            }
         }
     }
 
-
-    LaunchedEffect(sectionList) {
-        if (sectionList.isNotEmpty() && carentNum == 0) {
-            carentNum = sectionList.first().todoSectionNum
+    // `selectedItem` の状態管理
+    LaunchedEffect(selectedItem) {
+        if (selectedItem != null) {
+            sheetState.show()
+        } else {
+            sheetState.hide()
         }
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.weight(1f)) {
             ScrollList(
-                listState = scrollListState,
-                todoList = todoList,
-                onItemClicked = { /* アイテムクリック処理 */ },
-                onSectionSelected = { selectedNum ->
-                    carentNum = selectedNum // `carentNum` を更新
-                },
+                listState = listState, // 修正: 統一
+                todoList = filteredTodoList, // 修正: 事前にフィルタリング
+                onItemClicked = { selectedItem = it },
+                onSectionSelected = { selectedNum -> carentNum = selectedNum },
                 sectionList = sectionList,
-                carentNum = carentNum // // 現在のセクション番号を渡す
+                carentNum = carentNum,
+                scope = scope,
+                todoDao = todoDao
             )
 
             FloatingButtons(
@@ -97,14 +108,12 @@ fun MainComponent(todoDao: TodoDao) {
                 },
                 onListAdd = { showDialog = true },
                 onSearchClick = {
-                    // 検索処理（例: 検索ダイアログを開く）
-                    println("検索ボタンがクリックされました") //todo 検索処理
-                },
+                    println("検索ボタンがクリックされました")
+                }
             )
         }
     }
 
-    // **`ModalBottomSheet` を `FloatingButtons` の外に移動**
     if (selectedItem != null) {
         ModalBottomSheet(
             onDismissRequest = { selectedItem = null },
@@ -114,7 +123,6 @@ fun MainComponent(todoDao: TodoDao) {
         }
     }
 
-    // **Compose_plus.kt の `AddSectionDialog` を呼び出す**
     AddSectionDialog(
         showDialog = showDialog,
         onDismiss = { showDialog = false },
@@ -179,7 +187,9 @@ fun ScrollList(
     onItemClicked: (Todo) -> Unit,
     onSectionSelected: (Int) -> Unit,
     sectionList: List<TodoSection>,
-    carentNum: Int
+    carentNum: Int,
+    scope: CoroutineScope,
+    todoDao: TodoDao
 ) {
     val filteredTodoList by remember(todoList, carentNum) {
         mutableStateOf(todoList.filter { it.sectionNum == carentNum })
@@ -202,6 +212,11 @@ fun ScrollList(
         }
 
         items(filteredTodoList) { todo ->
+            SwipeToDeleteTodo(todo) { deletedTodo ->
+                scope.launch(Dispatchers.IO) {
+                    todoDao.markAsDeleted(deletedTodo.id)
+                }
+            }
             Text(
                 text = buildAnnotatedString {
                     withStyle(style = SpanStyle(color = Color.Blue)) { // タイトルを青色に変更

--- a/app/src/main/java/com/ts/jpc_test/Compose.kt
+++ b/app/src/main/java/com/ts/jpc_test/Compose.kt
@@ -1,6 +1,5 @@
 package com.ts.jpc_test
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -24,7 +23,6 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -32,58 +30,58 @@ import kotlinx.coroutines.withContext
 // データクラス : ヘッダーのセクション情報を保持
 data class Headtitle(val title: String)
 
-@SuppressLint("UnrememberedMutableState")
+// Composable関数 : メイン画面のUIを構築
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun MainComponent(todoDao: TodoDao) {
-    val listState = rememberLazyListState()  // 修正: 統一
+fun MainComponent(sectionDao: SectionDao, todoDao: TodoDao) {
+    val listState = rememberLazyListState()
     val sheetState = rememberModalBottomSheetState()
     val scope = rememberCoroutineScope()
     var selectedItem by remember { mutableStateOf<Todo?>(null) }
-    val todoList by todoDao.getActiveTodos().collectAsState(initial = emptyList())
-    val sectionList by todoDao.getAllSections().collectAsState(initial = emptyList()) // セクションリスト取得
-
+    val todoList by todoDao.getAll().collectAsState(initial = emptyList())
+    val sectionListState = sectionDao.getAllSections().collectAsState(initial = emptyList())
+    val sectionList = sectionListState.value.filter { !it.todoOnDeleted } // フィルタリング
     var carentNum by remember { mutableStateOf(0) } // 選択されたセクション番号
-    var showDialog by remember { mutableStateOf(false) } // ダイアログ表示状態
+    var canShowDialog by remember { mutableStateOf(false) } // ダイアログ表示状態
+    val scrollListState = rememberLazyListState()   // LazyColumn用
+    val headerRowListState = rememberLazyListState()  // LazyRow用（新規に追加）
 
-    // `filteredTodoList` を `derivedStateOf` で最適化
-    val filteredTodoList by derivedStateOf {
-        todoList.filter { it.sectionNum == carentNum }
-    }
-
-    // DBアクセスの最適化
+    // 最初のセクションで初期値を挿入
     LaunchedEffect(Unit) {
         scope.launch(Dispatchers.IO) {
-            val sectionId = initialAccess(todoDao) ?: return@launch
+            val sectionId = initialAccess(sectionDao, todoDao) ?: return@launch
             withContext(Dispatchers.Main) {
-                carentNum = sectionId
+                carentNum = sectionId // 例のセクション番号を設定
             }
         }
     }
 
-    // `selectedItem` の状態管理
-    LaunchedEffect(selectedItem) {
-        if (selectedItem != null) {
-            sheetState.show()
-        } else {
-            sheetState.hide()
+    // 削除後に移動するため、最初の `carentNum` を設定
+    LaunchedEffect(sectionList) {
+        if (sectionList.isNotEmpty() && carentNum == 0) {
+            carentNum = sectionList.first().todoSectionNum
         }
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.weight(1f)) {
             ScrollList(
-                listState = listState, // 修正: 統一
-                todoList = filteredTodoList, // 修正: 事前にフィルタリング
-                onItemClicked = { selectedItem = it },
-                onSectionSelected = { selectedNum -> carentNum = selectedNum },
+                listState = scrollListState,
+                todoList = todoList,
+                onItemClicked = { /* アイテムクリック処理 */ },
+                onSectionSelected = { selectedNum ->
+                    carentNum = selectedNum // `carentNum` を更新
+                },
                 sectionList = sectionList,
-                carentNum = carentNum,
-                scope = scope,
-                todoDao = todoDao
+                carentNum = carentNum, // 現在のセクション番号を渡す
+                headerRowListState = headerRowListState
             )
 
             FloatingButtons(
+                todoDao = todoDao,
+                sectionDao = sectionDao,
+                carentNum = carentNum,
+                onCarentNumChange = { newCarentNum -> carentNum = newCarentNum },
                 onAddClick = {
                     scope.launch(Dispatchers.IO) {
                         todoDao.insert(
@@ -99,36 +97,41 @@ fun MainComponent(todoDao: TodoDao) {
                         )
                     }
                 },
-                onDeleteClick = {
-                    selectedItem?.let { todo ->
-                        scope.launch(Dispatchers.IO) {
-                            todoDao.delete(todo)
+                onDeleteClick = { // ここで削除処理を追加
+                    scope.launch(Dispatchers.IO) {
+                        sectionDao.logicallyDeleteSection(carentNum) // 論理削除
+
+                        // **削除後の遷移先を決定**
+                        val updatedSections =
+                            todoDao.getAllSectionsNow().filter { !it.todoOnDeleted }
+                        val currentIndex =
+                            updatedSections.indexOfFirst { it.todoSectionNum == carentNum }
+
+                        if (updatedSections.isNotEmpty()) {
+                            val newCarentNum = if (currentIndex > 0) {
+                                updatedSections[currentIndex - 1].todoSectionNum // 左のグループに移動
+                            } else {
+                                updatedSections.first().todoSectionNum // 先頭のグループに移動
+                            }
+                            withContext(Dispatchers.Main) {
+                                carentNum = newCarentNum // `carentNum` を更新
+                            }
                         }
                     }
                 },
-                onListAdd = { showDialog = true },
-                onSearchClick = {
-                    println("検索ボタンがクリックされました")
-                }
+                onListAdd = { canShowDialog = true },
+                onSearchClick = { println("検索ボタンがクリックされました") }
             )
         }
     }
 
-    if (selectedItem != null) {
-        ModalBottomSheet(
-            onDismissRequest = { selectedItem = null },
-            sheetState = sheetState
-        ) {
-            DetailComponent(selectedItem!!)
-        }
-    }
-
+    // **Compose_plus.kt の `AddSectionDialog` を呼び出す**
     AddSectionDialog(
-        showDialog = showDialog,
-        onDismiss = { showDialog = false },
+        showDialog = canShowDialog,
+        onDismiss = { canShowDialog = false },
         onConfirm = { inputText ->
             scope.launch(Dispatchers.IO) {
-                todoDao.insertSection(
+                sectionDao.insertSection(
                     TodoSection(
                         todoSectionTitle = inputText,
                         todoOnDeleted = false
@@ -188,11 +191,10 @@ fun ScrollList(
     onSectionSelected: (Int) -> Unit,
     sectionList: List<TodoSection>,
     carentNum: Int,
-    scope: CoroutineScope,
-    todoDao: TodoDao
+    headerRowListState: LazyListState
 ) {
     val filteredTodoList by remember(todoList, carentNum) {
-        mutableStateOf(todoList.filter { it.sectionNum == carentNum })
+        derivedStateOf { todoList.filter { it.sectionNum == carentNum } }
     }
 
     LazyColumn(state = listState) {
@@ -207,16 +209,11 @@ fun ScrollList(
                 onItemSelected = { selectedNum ->
                     onSectionSelected(selectedNum) // `carentNum` を更新
                 },
-                listState = listState
+                listState = headerRowListState
             )
         }
 
         items(filteredTodoList) { todo ->
-            SwipeToDeleteTodo(todo) { deletedTodo ->
-                scope.launch(Dispatchers.IO) {
-                    todoDao.markAsDeleted(deletedTodo.id)
-                }
-            }
             Text(
                 text = buildAnnotatedString {
                     withStyle(style = SpanStyle(color = Color.Blue)) { // タイトルを青色に変更
@@ -251,4 +248,3 @@ fun DetailComponent(todo: Todo) {
         Text(text = "タグ: ${todo.tag}", style = MaterialTheme.typography.bodySmall)
     }
 }
-

--- a/app/src/main/java/com/ts/jpc_test/Compose.kt
+++ b/app/src/main/java/com/ts/jpc_test/Compose.kt
@@ -30,54 +30,83 @@ data class Headtitle(val title: String)
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun MainComponent(todoDao: TodoDao) {
-    val listState = rememberLazyListState() // リストのスクロール状態を管理
-    val sheetState = rememberModalBottomSheetState() // ボトムシートの状態を管理
-    val scope = rememberCoroutineScope() // 並行処理を管理するためのスコープ
-    var selectedItem by remember { mutableStateOf<Todo?>(null) } // 選択されたアイテムを記憶
-    val todoList by remember { todoDao.getAll() }.collectAsState(initial = emptyList())
+    val listState = rememberLazyListState()
+    val sheetState = rememberModalBottomSheetState()
+    val scope = rememberCoroutineScope()
+    var selectedItem by remember { mutableStateOf<Todo?>(null) }
+    val todoList by todoDao.getAll().collectAsState(initial = emptyList())
+    val sectionList by todoDao.getAllSections().collectAsState(initial = emptyList()) // セクションリスト取得
 
-    // ボタン押下時の処理を定義
-    val onAddClick: () -> Unit = {
-        scope.launch(Dispatchers.IO) { // I/O スレッドで処理
-            todoDao.insert(Todo(section = "1", title = "新しいTodo", text = "詳細", onChecked = false, tag = "タグ", quantity = 0, onDeleted = false))
-        }
-    }
-
-    val onDeleteClick: (Todo) -> Unit = { todo ->
-        scope.launch(Dispatchers.IO) { // I/O スレッドで処理
-            todoDao.delete(todo)
-        }
-    }
+    var carentNum by remember { mutableStateOf(0) } // 選択されたセクション番号
+    var showDialog by remember { mutableStateOf(false) } // ダイアログ表示状態
+    val scrollListState = rememberLazyListState()
 
     Column(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.weight(1f)) {
             ScrollList(
-                listState = listState,
+                listState = scrollListState,
                 todoList = todoList,
-                onItemClicked = { todo ->
-                    selectedItem = todo
-                    scope.launch { sheetState.show() }
-                }
+                onItemClicked = { /* アイテムクリック処理 */ },
+                onSectionSelected = { selectedNum ->
+                    carentNum = selectedNum // `carentNum` を更新
+                },
+                sectionList = sectionList,
+                carentNum = carentNum // // 現在のセクション番号を渡す
             )
 
-            // ボタンの処理を渡す
             FloatingButtons(
-                onAddClick = onAddClick,
-                onDeleteClick = { selectedItem?.let(onDeleteClick) }
+                onAddClick = {
+                    scope.launch(Dispatchers.IO) {
+                        todoDao.insert(
+                            Todo(
+                                sectionNum = carentNum,
+                                title = "新しいTodo",
+                                text = "詳細",
+                                onChecked = false,
+                                tag = "タグ",
+                                quantity = 0,
+                                onDeleted = false
+                            )
+                        )
+                    }
+                },
+                onDeleteClick = {
+                    selectedItem?.let { todo ->
+                        scope.launch(Dispatchers.IO) {
+                            todoDao.delete(todo)
+                        }
+                    }
+                },
+                onListAdd = { showDialog = true },
+                onSearchClick = {
+                    // 検索処理（例: 検索ダイアログを開く）
+                    println("検索ボタンがクリックされました")
+                },
             )
-
-            if (selectedItem != null) {
-                ModalBottomSheet(
-                    onDismissRequest = { selectedItem = null },
-                    sheetState = sheetState
-                ) {
-                    DetailComponent(selectedItem!!)
-                }
-            }
         }
     }
-}
 
+    // **`ModalBottomSheet` を `FloatingButtons` の外に移動**
+    if (selectedItem != null) {
+        ModalBottomSheet(
+            onDismissRequest = { selectedItem = null },
+            sheetState = sheetState
+        ) {
+            DetailComponent(selectedItem!!)
+        }
+    }
+
+    // **Compose_plus.kt の `AddSectionDialog` を呼び出す**
+    AddSectionDialog(
+        showDialog = showDialog,
+        onDismiss = { showDialog = false },
+        onConfirm = { inputText ->
+            scope.launch(Dispatchers.IO) {
+                todoDao.insertSection(TodoSection(todoSectionTitle = inputText))
+            }
+        }
+    )
+}
 
 // トップバーのComposable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -124,32 +153,28 @@ fun AppTopBar() {
 fun ScrollList(
     listState: LazyListState,
     todoList: List<Todo>,
-    onItemClicked: (Todo) -> Unit
+    onItemClicked: (Todo) -> Unit,
+    onSectionSelected: (Int) -> Unit,
+    sectionList: List<TodoSection>, // セクションのリストを受け取る
+    carentNum: Int
 ) {
     LazyColumn(state = listState) {
-        // トップバー
         item {
             AppTopBar()
         }
 
-        // 固定ヘッダー
+        // **セクションをDBから取得し表示**
         stickyHeader {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(60.dp)
-                    .background(Color(0xFF9DC183)), // ヘッダーの背景色
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = "Todoリスト",
-                    style = MaterialTheme.typography.headlineLarge,
-                    color = Color.White
-                )
-            }
+            HeadtitleList(
+                headtitles = sectionList.map { Headtitle(it.todoSectionTitle) },
+                carentNum = carentNum,
+                onItemSelected = { selectedNum ->
+                    onSectionSelected(selectedNum) // `carentNum` を更新
+                },
+                listState = listState // `listState` を渡す
+            )
         }
 
-        // Todo リスト
         items(todoList) { todo ->
             Text(
                 text = "${todo.title}: ${todo.quantity}",
@@ -158,7 +183,7 @@ fun ScrollList(
                     .padding(16.dp)
                     .background(Color.White, RoundedCornerShape(8.dp))
                     .padding(16.dp)
-                    .clickable { onItemClicked(todo) }, // `Todo` を渡す
+                    .clickable { onItemClicked(todo) },
                 color = Color.Black
             )
         }

--- a/app/src/main/java/com/ts/jpc_test/Compose.kt
+++ b/app/src/main/java/com/ts/jpc_test/Compose.kt
@@ -18,7 +18,10 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -40,6 +43,21 @@ fun MainComponent(todoDao: TodoDao) {
     var carentNum by remember { mutableStateOf(0) } // 選択されたセクション番号
     var showDialog by remember { mutableStateOf(false) } // ダイアログ表示状態
     val scrollListState = rememberLazyListState()
+
+    //最初のセクションで初期値を挿入
+    LaunchedEffect(Unit) {
+        scope.launch(Dispatchers.IO) {
+            val sectionId = initialAccess(todoDao) ?: return@launch
+            carentNum = sectionId // 例のセクション番号を設定
+        }
+    }
+
+
+    LaunchedEffect(sectionList) {
+        if (sectionList.isNotEmpty() && carentNum == 0) {
+            carentNum = sectionList.first().todoSectionNum
+        }
+    }
 
     Column(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.weight(1f)) {
@@ -80,7 +98,7 @@ fun MainComponent(todoDao: TodoDao) {
                 onListAdd = { showDialog = true },
                 onSearchClick = {
                     // 検索処理（例: 検索ダイアログを開く）
-                    println("検索ボタンがクリックされました")
+                    println("検索ボタンがクリックされました") //todo 検索処理
                 },
             )
         }
@@ -102,7 +120,12 @@ fun MainComponent(todoDao: TodoDao) {
         onDismiss = { showDialog = false },
         onConfirm = { inputText ->
             scope.launch(Dispatchers.IO) {
-                todoDao.insertSection(TodoSection(todoSectionTitle = inputText))
+                todoDao.insertSection(
+                    TodoSection(
+                        todoSectionTitle = inputText,
+                        todoOnDeleted = false
+                    )
+                )
             }
         }
     )
@@ -155,41 +178,49 @@ fun ScrollList(
     todoList: List<Todo>,
     onItemClicked: (Todo) -> Unit,
     onSectionSelected: (Int) -> Unit,
-    sectionList: List<TodoSection>, // セクションのリストを受け取る
+    sectionList: List<TodoSection>,
     carentNum: Int
 ) {
+    val filteredTodoList by remember(todoList, carentNum) {
+        mutableStateOf(todoList.filter { it.sectionNum == carentNum })
+    }
+
     LazyColumn(state = listState) {
         item {
             AppTopBar()
         }
 
-        // **セクションをDBから取得し表示**
         stickyHeader {
             HeadtitleList(
-                headtitles = sectionList.map { Headtitle(it.todoSectionTitle) },
+                headtitles = sectionList,
                 carentNum = carentNum,
                 onItemSelected = { selectedNum ->
                     onSectionSelected(selectedNum) // `carentNum` を更新
                 },
-                listState = listState // `listState` を渡す
+                listState = listState
             )
         }
 
-        items(todoList) { todo ->
+        items(filteredTodoList) { todo ->
             Text(
-                text = "${todo.title}: ${todo.quantity}",
+                text = buildAnnotatedString {
+                    withStyle(style = SpanStyle(color = Color.Blue)) { // タイトルを青色に変更
+                        append(todo.title)
+                    }
+                    append(": ${todo.text}") // テキスト部分はそのまま
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(16.dp)
                     .background(Color.White, RoundedCornerShape(8.dp))
                     .padding(16.dp)
                     .clickable { onItemClicked(todo) },
-                color = Color.Black
+                color = Color.Black // デフォルトの文字色
             )
         }
+
     }
 }
-
 
 // 詳細画面 (ボトムシート)
 @Composable

--- a/app/src/main/java/com/ts/jpc_test/Compose.kt
+++ b/app/src/main/java/com/ts/jpc_test/Compose.kt
@@ -33,7 +33,7 @@ data class Headtitle(val title: String)
 // Composable関数 : メイン画面のUIを構築
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun MainComponent(sectionDao: SectionDao, todoDao: TodoDao) {
+fun MainComponent(sectionDao: TodoSectionDao, todoDao: TodoDao) {
     val listState = rememberLazyListState()
     val sheetState = rememberModalBottomSheetState()
     val scope = rememberCoroutineScope()
@@ -92,14 +92,14 @@ fun MainComponent(sectionDao: SectionDao, todoDao: TodoDao) {
                                 onChecked = false,
                                 tag = "タグ",
                                 quantity = 0,
-                                onDeleted = false
+                                isDeleted = false
                             )
                         )
                     }
                 },
                 onDeleteClick = { // ここで削除処理を追加
                     scope.launch(Dispatchers.IO) {
-                        sectionDao.logicallyDeleteSection(carentNum) // 論理削除
+                        sectionDao.deleteLogicallySection(carentNum) // 論理削除
 
                         // **削除後の遷移先を決定**
                         val updatedSections =
@@ -131,7 +131,7 @@ fun MainComponent(sectionDao: SectionDao, todoDao: TodoDao) {
         onDismiss = { canShowDialog = false },
         onConfirm = { inputText ->
             scope.launch(Dispatchers.IO) {
-                sectionDao.insertSection(
+                sectionDao.insert(
                     TodoSection(
                         todoSectionTitle = inputText,
                         todoOnDeleted = false

--- a/app/src/main/java/com/ts/jpc_test/Compose.kt
+++ b/app/src/main/java/com/ts/jpc_test/Compose.kt
@@ -39,7 +39,7 @@ fun MainComponent(todoDao: TodoDao) {
     // ボタン押下時の処理を定義
     val onAddClick: () -> Unit = {
         scope.launch(Dispatchers.IO) { // I/O スレッドで処理
-            todoDao.insert(Todo(section = "1", title = "新しいTodo", text = "詳細", isChecked = true, tag = "タグ", quantity = 0))
+            todoDao.insert(Todo(section = "1", title = "新しいTodo", text = "詳細", onChecked = false, tag = "タグ", quantity = 0, onDeleted = false))
         }
     }
 

--- a/app/src/main/java/com/ts/jpc_test/Compose_plus.kt
+++ b/app/src/main/java/com/ts/jpc_test/Compose_plus.kt
@@ -1,8 +1,11 @@
 package com.ts.jpc_test
 
+import androidx.compose.material3.AlertDialog
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -12,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -25,6 +29,8 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -39,6 +45,7 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 //縁取り文字を作成するfun
@@ -76,21 +83,26 @@ fun OutlinedText(
     )
 }
 
-//座標が固定されているボタンアイコン
 @Composable
 fun FloatingButtons(
     onAddClick: () -> Unit,
-    onDeleteClick: () -> Unit
+    onDeleteClick: () -> Unit,
+    onSearchClick: () -> Unit,
+    onListAdd: () -> Unit
 ) {
+    val smallButtonSize = 56.dp
+    val bigButtonSize = 80.dp
+    val distance = 80.dp
+
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp), // 画面全体をカバー
-        contentAlignment = Alignment.BottomEnd // 右下を基準点に配置
+            .padding(16.dp),
+        contentAlignment = Alignment.BottomEnd
     ) {
         // 小さいボタン（真上）
         FloatingActionButton(
-            onClick = { /* 真上のボタンの処理 */ },
+            onClick = onSearchClick, // 検索処理
             modifier = Modifier
                 .size(smallButtonSize)
                 .align(Alignment.BottomEnd)
@@ -101,28 +113,28 @@ fun FloatingButtons(
             Icon(Icons.Filled.Search, contentDescription = "検索", tint = Color.White)
         }
 
-        // 小さいボタン（真横）
+        // 小さいボタン（斜め左上）
         FloatingActionButton(
-            onClick = { /* 真横のボタンの処理 */ },
+            onClick = onListAdd, // 設定処理
             modifier = Modifier
                 .size(smallButtonSize)
                 .align(Alignment.BottomEnd)
-                .offset(x = -distance * 0.8f, y = -distance * 0.8f), // 真左に配置
+                .offset(x = -distance * 0.8f, y = -distance * 0.8f), // 斜め左上に配置
             shape = RoundedCornerShape(50),
             containerColor = Color(0xFF9DC183)
         ) {
-            Icon(Icons.Filled.Settings, contentDescription = "設定", tint = Color.White)
+            Icon(Icons.Filled.Add, contentDescription = "横スクロールアイテム追加", tint = Color.White)
         }
 
-        // 小さいボタン（真横）
+        // 小さいボタン（真左）
         FloatingActionButton(
-            onClick = { /* 真横のボタンの処理 */ },
+            onClick = onDeleteClick, // 削除処理
             modifier = Modifier
                 .size(smallButtonSize)
                 .align(Alignment.BottomEnd)
                 .offset(x = -distance), // 真左に配置
             shape = RoundedCornerShape(50),
-            containerColor = Color(0xFFFFB6C1)
+            containerColor = Color(0xFFFFB6C1) // ピンク
         ) {
             Icon(
                 imageVector = Icons.Filled.Delete, // ゴミ箱アイコン
@@ -133,7 +145,7 @@ fun FloatingButtons(
 
         // 中央の大きなボタン（プラスマーク）
         FloatingActionButton(
-            onClick = { /* 大ボタンの処理 */ },
+            onClick = onAddClick, // 追加処理
             modifier = Modifier
                 .size(bigButtonSize)
                 .align(Alignment.BottomEnd), // 右下に固定
@@ -145,64 +157,108 @@ fun FloatingButtons(
     }
 }
 
+
+
 // 横スクロール可能な見出しリスト
 @Composable
-fun HeadtitleList(headtitles: List<Headtitle>) {
+fun HeadtitleList(
+    headtitles: List<Headtitle>,
+    carentNum: Int, // 現在選択されているセクション
+    onItemSelected: (Int) -> Unit,
+    listState: LazyListState // スクロール制御のための state
+) {
     LazyRow(
         modifier = Modifier
             .fillMaxWidth()
-            .background(Color(0)),
+            .background(Color(0xFF9DC183)),
+        state = listState,
         horizontalArrangement = Arrangement.spacedBy(16.dp)
+
     ) {
         itemsIndexed(headtitles) { index, headtitle ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
+            Box(
+                modifier = Modifier
+                    .width(120.dp) // 固定幅を設定
+                    .height(50.dp)
+                    .clickable {
+                        onItemSelected(index) // コールバックで選択情報を渡す
+                    }
+                    .background(
+                        Color.Transparent,
+                        shape = RoundedCornerShape(8.dp)
+                    ),
+                contentAlignment = Alignment.Center
             ) {
                 Text(
                     text = headtitle.title,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis, // 長すぎる場合は "..." に省略
                     modifier = Modifier
                         .padding(horizontal = 5.dp, vertical = 8.dp)
-                        .background(Color.Transparent, shape = RoundedCornerShape(8.dp)) // 背景を透明に
-                        .padding(2.dp)
-                        .wrapContentSize(align = Alignment.Center), // 縦横どちらも中央配置
+                        .wrapContentSize(align = Alignment.Center),
                     style = TextStyle(
                         fontSize = MaterialTheme.typography.titleLarge.fontSize.times(0.7f),
-                        color = Color.White, // 白文字
+                        color = if (carentNum == index) Color.Black else Color.White,
                         textAlign = TextAlign.Center
                     )
                 )
+
                 // 最後のアイテムの後に Divider を描画しない
                 if (index < headtitles.lastIndex) {
                     HorizontalDivider(
                         modifier = Modifier
                             .width(1.dp)
-                            .height(8.dp) // Divider の高さを調整
-                            .align(Alignment.CenterVertically),
+                            .height(8.dp),
                         thickness = 1.dp,
                         color = Color.Gray
                     )
                 }
             }
         }
-        // **スクロールの最後に + ボタンを追加**
-        item {
-            FloatingActionButton(
-                onClick = { /* 追加ボタンの処理 */ },
-                modifier = Modifier
-                    .offset(y = 5.dp)
-                    .size(smallButtonSize * 0.7f),
-                shape = RoundedCornerShape(50),
-                containerColor = Color(0xFFFFFFFF) // 淡いピンク
-            ) {
-                Icon(
-                    modifier = Modifier
-                        .padding(8.dp),
-                    imageVector = Icons.Filled.Add,
-                    contentDescription = "追加",
-                    tint = Color.Black
-                )
-            }
-        }
     }
 }
+
+@Composable
+fun AddSectionDialog(
+    showDialog: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit
+) {
+    var inputText by remember { mutableStateOf("") } // 入力テキストを管理
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = { Text("新しいセクションを追加") },
+            text = {
+                Column {
+                    Text("セクション名を入力してください:")
+                    TextField(
+                        value = inputText,
+                        onValueChange = { inputText = it },
+                        singleLine = true
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        if (inputText.isNotBlank()) {
+                            onConfirm(inputText) // 確定時にテキストを渡す
+                            inputText = "" // 入力をリセット
+                            onDismiss() // ダイアログを閉じる
+                        }
+                    }
+                ) {
+                    Text("追加")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onDismiss) {
+                    Text("キャンセル")
+                }
+            }
+        )
+    }
+}
+

--- a/app/src/main/java/com/ts/jpc_test/Compose_plus.kt
+++ b/app/src/main/java/com/ts/jpc_test/Compose_plus.kt
@@ -3,7 +3,6 @@ package com.ts.jpc_test
 import androidx.compose.material3.AlertDialog
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,16 +32,17 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
@@ -70,35 +70,37 @@ fun OutlinedText(
     var textLayoutResult: TextLayoutResult? by remember {
         mutableStateOf(null)
     }
-    Text(
-        text = text,
-        style = textStyle,
-        onTextLayout = {
-            textLayoutResult = it
-        },
-        modifier = modifier
-            .drawBehind {
-                textLayoutResult?.let {
-                    drawText(
-                        textLayoutResult = it,
-                        drawStyle = stroke,
-                        color = strokeColor,
-                    )
-                }
-            }
-    )
+    Text(text = text, style = textStyle, onTextLayout = {
+        textLayoutResult = it
+    }, modifier = modifier.drawBehind {
+        textLayoutResult?.let {
+            drawText(
+                textLayoutResult = it,
+                drawStyle = stroke,
+                color = strokeColor,
+            )
+        }
+    })
 }
 
 @Composable
 fun FloatingButtons(
+    todoDao: TodoDao,
+    sectionDao: SectionDao,
+    carentNum: Int,
+    onCarentNumChange: (Int) -> Unit,
     onAddClick: () -> Unit,
     onDeleteClick: () -> Unit,
     onSearchClick: () -> Unit,
-    onListAdd: () -> Unit
+    onListAdd: () -> Unit,
 ) {
     val smallButtonSize = 56.dp
     val bigButtonSize = 80.dp
     val distance = 80.dp
+    val scope = rememberCoroutineScope()
+    var showDeleteDialog by remember { mutableStateOf(false) }
+    val sectionListState = sectionDao.getAllSections().collectAsState(initial = emptyList())
+    val sectionList = sectionListState.value.filter { !it.todoOnDeleted }
 
     Box(
         modifier = Modifier
@@ -112,7 +114,7 @@ fun FloatingButtons(
             modifier = Modifier
                 .size(smallButtonSize)
                 .align(Alignment.BottomEnd)
-                .offset(y = -distance), // 真上に配置
+                .offset(y = -distance),
             shape = RoundedCornerShape(50),
             containerColor = Color(0xFF1E90FF) // 明るめのブルー
         ) {
@@ -121,28 +123,24 @@ fun FloatingButtons(
 
         // 小さいボタン（斜め左上）
         FloatingActionButton(
-            onClick = onListAdd, // 設定処理
+            onClick = onListAdd, // グループ追加処理
             modifier = Modifier
                 .size(smallButtonSize)
                 .align(Alignment.BottomEnd)
-                .offset(x = -distance * 0.8f, y = -distance * 0.8f), // 斜め左上に配置
+                .offset(x = -distance * 0.8f, y = -distance * 0.8f),
             shape = RoundedCornerShape(50),
             containerColor = Color(0xFF9DC183)
         ) {
-            Icon(
-                Icons.Filled.Add,
-                contentDescription = "横スクロールアイテム追加",
-                tint = Color.White
-            )
+            Icon(Icons.Filled.Add, contentDescription = "グループ追加", tint = Color.White)
         }
 
         // 小さいボタン（真左）
         FloatingActionButton(
-            onClick = onDeleteClick, // 削除処理
+            onClick = { showDeleteDialog = true }, // 削除ダイアログを開く
             modifier = Modifier
                 .size(smallButtonSize)
                 .align(Alignment.BottomEnd)
-                .offset(x = -distance), // 真左に配置
+                .offset(x = -distance),
             shape = RoundedCornerShape(50),
             containerColor = Color(0xFFFFB6C1) // ピンク
         ) {
@@ -153,25 +151,51 @@ fun FloatingButtons(
             )
         }
 
-        // 中央の大きなボタン（プラスマーク）
+        // 中央の大きなボタン（追加）
         FloatingActionButton(
             onClick = onAddClick, // 追加処理
             modifier = Modifier
                 .size(bigButtonSize)
-                .align(Alignment.BottomEnd), // 右下に固定
+                .align(Alignment.BottomEnd),
             shape = RoundedCornerShape(50),
             containerColor = Color(0xFF00BFFF) // 明るい水色
         ) {
             Icon(Icons.Filled.Add, contentDescription = "追加", tint = Color.White)
         }
     }
-}
 
+    // 削除確認ダイアログ
+    DeleteConfirmationDialog(
+        showDialog = showDeleteDialog,
+        onDismiss = { showDeleteDialog = false },
+        onConfirm = {
+            scope.launch(Dispatchers.IO) {
+                sectionDao.deleteSection(carentNum) // 現在のグループを論理削除
+
+                // **削除後の遷移先を決定**
+                val updatedSections = todoDao.getAllSectionsNow().filter { !it.todoOnDeleted }
+                val currentIndex = updatedSections.indexOfFirst { it.todoSectionNum == carentNum }
+
+                if (updatedSections.isNotEmpty()) {
+                    val newCarentNum = if (currentIndex > 0) {
+                        updatedSections[currentIndex - 1].todoSectionNum // 左のグループに移動
+                    } else {
+                        updatedSections.first().todoSectionNum // 先頭のグループに移動
+                    }
+                    withContext(Dispatchers.Main) {
+                        onCarentNumChange(newCarentNum) // `carentNum` を更新
+                    }
+                }
+            }
+            showDeleteDialog = false
+        }
+    )
+}
 
 // 横スクロール可能な見出しリスト
 @Composable
 fun HeadtitleList(
-    headtitles: List<TodoSection>,
+    headtitles: List<TodoSection>, // 修正後のリストを渡す
     carentNum: Int,
     onItemSelected: (Int) -> Unit,
     listState: LazyListState
@@ -184,20 +208,16 @@ fun HeadtitleList(
         horizontalArrangement = Arrangement.spacedBy(16.dp)
 
     ) {
-        itemsIndexed(headtitles) { _, headtitle -> // `index` ではなく `headtitle`
-            Box(
-                modifier = Modifier
-                    .width(120.dp)
-                    .height(50.dp)
-                    .clickable {
-                        onItemSelected(headtitle.todoSectionNum) // `todoSectionNum` を渡す
-                    }
-                    .background(
-                        Color.Transparent,
-                        shape = RoundedCornerShape(8.dp)
-                    ),
-                contentAlignment = Alignment.Center
-            ) {
+        itemsIndexed(headtitles.filter { !it.todoOnDeleted }) { _, headtitle ->
+            Box(modifier = Modifier
+                .width(120.dp)
+                .height(50.dp)
+                .clickable {
+                    onItemSelected(headtitle.todoSectionNum) // `todoSectionNum` を渡す
+                }
+                .background(
+                    Color.Transparent, shape = RoundedCornerShape(8.dp)
+                ), contentAlignment = Alignment.Center) {
                 Text(
                     text = headtitle.todoSectionTitle,
                     maxLines = 1,
@@ -216,39 +236,31 @@ fun HeadtitleList(
     }
 }
 
-
 @Composable
 fun AddSectionDialog(
-    showDialog: Boolean,
-    onDismiss: () -> Unit,
-    onConfirm: (String) -> Unit
+    showDialog: Boolean, onDismiss: () -> Unit, onConfirm: (String) -> Unit
 ) {
     var inputText by remember { mutableStateOf("") } // 入力テキストを管理
 
     if (showDialog) {
-        AlertDialog(
-            onDismissRequest = onDismiss,
+        AlertDialog(onDismissRequest = onDismiss,
             title = { Text("新しいセクションを追加") },
             text = {
                 Column {
                     Text("セクション名を入力してください:")
                     TextField(
-                        value = inputText,
-                        onValueChange = { inputText = it },
-                        singleLine = true
+                        value = inputText, onValueChange = { inputText = it }, singleLine = true
                     )
                 }
             },
             confirmButton = {
-                TextButton(
-                    onClick = {
-                        if (inputText.isNotBlank()) {
-                            onConfirm(inputText) // 確定時にテキストを渡す
-                            inputText = "" // 入力をリセット
-                            onDismiss() // ダイアログを閉じる
-                        }
+                TextButton(onClick = {
+                    if (inputText.isNotBlank()) {
+                        onConfirm(inputText) // 確定時にテキストを渡す
+                        inputText = "" // 入力をリセット
+                        onDismiss() // ダイアログを閉じる
                     }
-                ) {
+                }) {
                     Text("追加")
                 }
             },
@@ -256,19 +268,17 @@ fun AddSectionDialog(
                 TextButton(onClick = onDismiss) {
                     Text("キャンセル")
                 }
-            }
-        )
+            })
     }
 }
 
-suspend fun initialAccess(todoDao: TodoDao): Int? {
+suspend fun initialAccess(sectionDao: SectionDao, todoDao: TodoDao): Int? {
     return withContext(Dispatchers.IO) {
-        if (todoDao.getSectionCount() == 0) {
+        if (sectionDao.getSectionCount() == 0) {
             val exampleSection = TodoSection(
-                todoSectionTitle = "例",
-                todoOnDeleted = false
+                todoSectionTitle = "例", todoOnDeleted = false
             )
-            val exampleSectionId: Long = todoDao.insertSection(exampleSection)
+            val exampleSectionId: Long = sectionDao.insertSection(exampleSection)
 
             // 直後にデータベースから ID を確認
             val updatedSections = todoDao.getAllSectionsNow()
@@ -334,14 +344,29 @@ suspend fun initialAccess(todoDao: TodoDao): Int? {
 }
 
 @Composable
-fun SwipeToDeleteTodo(todo: Todo, onDelete: (Todo) -> Unit) {
-    Box(
-        modifier = Modifier.fillMaxWidth().padding(8.dp).background(Color.White, RoundedCornerShape(8.dp)).pointerInput(Unit) {
-            detectHorizontalDragGestures { _, dragAmount -> if (dragAmount < -100) { onDelete(todo) } }
-        }.padding(16.dp)
-    ) {
-        Text(text = todo.title, color = Color.Black)
+fun DeleteConfirmationDialog(
+    showDialog: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = { Text("グループ削除の確認") },
+            text = { Text("本当にこのグループを削除しますか？") },
+            confirmButton = {
+                TextButton(onClick = {
+                    onConfirm() // 確定時の処理を実行
+                    onDismiss() // ダイアログを閉じる
+                }) {
+                    Text("削除")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onDismiss) {
+                    Text("キャンセル")
+                }
+            }
+        )
     }
 }
-
-

--- a/app/src/main/java/com/ts/jpc_test/Compose_plus.kt
+++ b/app/src/main/java/com/ts/jpc_test/Compose_plus.kt
@@ -86,7 +86,7 @@ fun OutlinedText(
 @Composable
 fun FloatingButtons(
     todoDao: TodoDao,
-    sectionDao: SectionDao,
+    sectionDao: TodoSectionDao,
     carentNum: Int,
     onCarentNumChange: (Int) -> Unit,
     onAddClick: () -> Unit,
@@ -272,13 +272,13 @@ fun AddSectionDialog(
     }
 }
 
-suspend fun initialAccess(sectionDao: SectionDao, todoDao: TodoDao): Int? {
+suspend fun initialAccess(sectionDao: TodoSectionDao, todoDao: TodoDao): Int? {
     return withContext(Dispatchers.IO) {
         if (sectionDao.getSectionCount() == 0) {
             val exampleSection = TodoSection(
                 todoSectionTitle = "例", todoOnDeleted = false
             )
-            val exampleSectionId: Long = sectionDao.insertSection(exampleSection)
+            val exampleSectionId: Long = sectionDao.insert(exampleSection)
 
             // 直後にデータベースから ID を確認
             val updatedSections = todoDao.getAllSectionsNow()
@@ -295,7 +295,7 @@ suspend fun initialAccess(sectionDao: SectionDao, todoDao: TodoDao): Int? {
                         onChecked = false,
                         tag = "デフォルト",
                         quantity = 1,
-                        onDeleted = false
+                        isDeleted = false
                     ),
                     Todo(
                         sectionNum = exampleSectionNum,
@@ -304,7 +304,7 @@ suspend fun initialAccess(sectionDao: SectionDao, todoDao: TodoDao): Int? {
                         onChecked = false,
                         tag = "デフォルト",
                         quantity = 1,
-                        onDeleted = false
+                        isDeleted = false
                     ),
                     Todo(
                         sectionNum = exampleSectionNum,
@@ -313,7 +313,7 @@ suspend fun initialAccess(sectionDao: SectionDao, todoDao: TodoDao): Int? {
                         onChecked = false,
                         tag = "デフォルト",
                         quantity = 1,
-                        onDeleted = false
+                        isDeleted = false
                     ),
                     Todo(
                         sectionNum = exampleSectionNum,
@@ -322,7 +322,7 @@ suspend fun initialAccess(sectionDao: SectionDao, todoDao: TodoDao): Int? {
                         onChecked = false,
                         tag = "デフォルト",
                         quantity = 1,
-                        onDeleted = false
+                        isDeleted = false
                     ),
                     Todo(
                         sectionNum = exampleSectionNum,
@@ -331,7 +331,7 @@ suspend fun initialAccess(sectionDao: SectionDao, todoDao: TodoDao): Int? {
                         onChecked = false,
                         tag = "デフォルト",
                         quantity = 1,
-                        onDeleted = false
+                        isDeleted = false
                     ),
                 )
             )

--- a/app/src/main/java/com/ts/jpc_test/Compose_plus.kt
+++ b/app/src/main/java/com/ts/jpc_test/Compose_plus.kt
@@ -3,6 +3,7 @@ package com.ts.jpc_test
 import androidx.compose.material3.AlertDialog
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,6 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
@@ -331,5 +333,15 @@ suspend fun initialAccess(todoDao: TodoDao): Int? {
     }
 }
 
+@Composable
+fun SwipeToDeleteTodo(todo: Todo, onDelete: (Todo) -> Unit) {
+    Box(
+        modifier = Modifier.fillMaxWidth().padding(8.dp).background(Color.White, RoundedCornerShape(8.dp)).pointerInput(Unit) {
+            detectHorizontalDragGestures { _, dragAmount -> if (dragAmount < -100) { onDelete(todo) } }
+        }.padding(16.dp)
+    ) {
+        Text(text = todo.title, color = Color.Black)
+    }
+}
 
 

--- a/app/src/main/java/com/ts/jpc_test/Compose_plus.kt
+++ b/app/src/main/java/com/ts/jpc_test/Compose_plus.kt
@@ -47,6 +47,10 @@ import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 //縁取り文字を作成するfun
 val smallButtonSize = 65.dp // 小さいボタンのサイズ
@@ -123,7 +127,11 @@ fun FloatingButtons(
             shape = RoundedCornerShape(50),
             containerColor = Color(0xFF9DC183)
         ) {
-            Icon(Icons.Filled.Add, contentDescription = "横スクロールアイテム追加", tint = Color.White)
+            Icon(
+                Icons.Filled.Add,
+                contentDescription = "横スクロールアイテム追加",
+                tint = Color.White
+            )
         }
 
         // 小さいボタン（真左）
@@ -158,14 +166,13 @@ fun FloatingButtons(
 }
 
 
-
 // 横スクロール可能な見出しリスト
 @Composable
 fun HeadtitleList(
-    headtitles: List<Headtitle>,
-    carentNum: Int, // 現在選択されているセクション
+    headtitles: List<TodoSection>,
+    carentNum: Int,
     onItemSelected: (Int) -> Unit,
-    listState: LazyListState // スクロール制御のための state
+    listState: LazyListState
 ) {
     LazyRow(
         modifier = Modifier
@@ -175,13 +182,13 @@ fun HeadtitleList(
         horizontalArrangement = Arrangement.spacedBy(16.dp)
 
     ) {
-        itemsIndexed(headtitles) { index, headtitle ->
+        itemsIndexed(headtitles) { _, headtitle -> // `index` ではなく `headtitle`
             Box(
                 modifier = Modifier
-                    .width(120.dp) // 固定幅を設定
+                    .width(120.dp)
                     .height(50.dp)
                     .clickable {
-                        onItemSelected(index) // コールバックで選択情報を渡す
+                        onItemSelected(headtitle.todoSectionNum) // `todoSectionNum` を渡す
                     }
                     .background(
                         Color.Transparent,
@@ -190,33 +197,23 @@ fun HeadtitleList(
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    text = headtitle.title,
+                    text = headtitle.todoSectionTitle,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis, // 長すぎる場合は "..." に省略
+                    overflow = TextOverflow.Ellipsis,
                     modifier = Modifier
                         .padding(horizontal = 5.dp, vertical = 8.dp)
                         .wrapContentSize(align = Alignment.Center),
                     style = TextStyle(
                         fontSize = MaterialTheme.typography.titleLarge.fontSize.times(0.7f),
-                        color = if (carentNum == index) Color.Black else Color.White,
+                        color = if (carentNum == headtitle.todoSectionNum) Color.Black else Color.White,
                         textAlign = TextAlign.Center
                     )
                 )
-
-                // 最後のアイテムの後に Divider を描画しない
-                if (index < headtitles.lastIndex) {
-                    HorizontalDivider(
-                        modifier = Modifier
-                            .width(1.dp)
-                            .height(8.dp),
-                        thickness = 1.dp,
-                        color = Color.Gray
-                    )
-                }
             }
         }
     }
 }
+
 
 @Composable
 fun AddSectionDialog(
@@ -261,4 +258,78 @@ fun AddSectionDialog(
         )
     }
 }
+
+suspend fun initialAccess(todoDao: TodoDao): Int? {
+    return withContext(Dispatchers.IO) {
+        if (todoDao.getSectionCount() == 0) {
+            val exampleSection = TodoSection(
+                todoSectionTitle = "例",
+                todoOnDeleted = false
+            )
+            val exampleSectionId: Long = todoDao.insertSection(exampleSection)
+
+            // 直後にデータベースから ID を確認
+            val updatedSections = todoDao.getAllSectionsNow()
+            val exampleSectionNum =
+                updatedSections.find { it.todoSectionTitle == "例" }?.todoSectionNum
+                    ?: return@withContext null
+
+            todoDao.insertTodos(
+                listOf(
+                    Todo(
+                        sectionNum = exampleSectionNum,
+                        title = "グループを追加",
+                        text = "緑色の＋ボタン",
+                        onChecked = false,
+                        tag = "デフォルト",
+                        quantity = 1,
+                        onDeleted = false
+                    ),
+                    Todo(
+                        sectionNum = exampleSectionNum,
+                        title = "グループを削除",
+                        text = "🗑ボタン",
+                        onChecked = false,
+                        tag = "デフォルト",
+                        quantity = 1,
+                        onDeleted = false
+                    ),
+                    Todo(
+                        sectionNum = exampleSectionNum,
+                        title = "アイテムを追加",
+                        text = "青色の＋ボタン",
+                        onChecked = false,
+                        tag = "デフォルト",
+                        quantity = 1,
+                        onDeleted = false
+                    ),
+                    Todo(
+                        sectionNum = exampleSectionNum,
+                        title = "アイテムを削除",
+                        text = "アイテムをスワイプ",
+                        onChecked = false,
+                        tag = "デフォルト",
+                        quantity = 1,
+                        onDeleted = false
+                    ),
+                    Todo(
+                        sectionNum = exampleSectionNum,
+                        title = "アイテムを検索",
+                        text = "🔍ボタン",
+                        onChecked = false,
+                        tag = "デフォルト",
+                        quantity = 1,
+                        onDeleted = false
+                    ),
+                )
+            )
+
+            return@withContext exampleSectionNum
+        } else {
+            return@withContext null
+        }
+    }
+}
+
+
 

--- a/app/src/main/java/com/ts/jpc_test/MainActivity.kt
+++ b/app/src/main/java/com/ts/jpc_test/MainActivity.kt
@@ -18,7 +18,7 @@ import com.ts.jpc_test.ui.theme.JPC_testTheme
 class MainActivity : ComponentActivity() {
     private lateinit var database: AppDatabase
     private lateinit var todoDao: TodoDao
-    private lateinit var sectionDao: SectionDao
+    private lateinit var sectionDao: TodoSectionDao
 
     // onCreate() メソッド:アクティビティが作成されたときに実行
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/ts/jpc_test/MainActivity.kt
+++ b/app/src/main/java/com/ts/jpc_test/MainActivity.kt
@@ -18,6 +18,8 @@ import com.ts.jpc_test.ui.theme.JPC_testTheme
 class MainActivity : ComponentActivity() {
     private lateinit var database: AppDatabase
     private lateinit var todoDao: TodoDao
+    private lateinit var sectionDao: SectionDao
+
     // onCreate() メソッド:アクティビティが作成されたときに実行
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState) // 親クラスのonCreateを呼び出し
@@ -25,6 +27,7 @@ class MainActivity : ComponentActivity() {
         // Room データベースのインスタンスを取得
         database = AppDatabase.getDatabase(this)
         todoDao = database.todoDao()
+        sectionDao = database.sectionDao()
         enableEdgeToEdge() // フルスクリーン(エッジからエッジまで描画)を有効化
 
         setContent { // Jetpack ComposeのUI
@@ -34,7 +37,7 @@ class MainActivity : ComponentActivity() {
 
                     Column(modifier = Modifier.padding(innerPadding)) {
                         // メインのUIを表示
-                        MainComponent(todoDao)
+                        MainComponent(sectionDao = sectionDao, todoDao = todoDao)
                     }
                 }
             }

--- a/app/src/main/java/com/ts/jpc_test/RoomDatabase.kt
+++ b/app/src/main/java/com/ts/jpc_test/RoomDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.RoomDatabase
 import android.content.Context
 
 
-@Database(entities = [Todo::class, TodoSection::class], version = 14, exportSchema = false)
+@Database(entities = [Todo::class, TodoSection::class], version = 17, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun todoDao(): TodoDao //DAO (Data Access Object) を取得するための抽象メソッド。
 

--- a/app/src/main/java/com/ts/jpc_test/RoomDatabase.kt
+++ b/app/src/main/java/com/ts/jpc_test/RoomDatabase.kt
@@ -9,7 +9,7 @@ import android.content.Context
 @Database(entities = [Todo::class, TodoSection::class], version = 1, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun todoDao(): TodoDao //DAO (Data Access Object) を取得するための抽象メソッド。
-    abstract fun sectionDao(): SectionDao
+    abstract fun sectionDao(): TodoSectionDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/ts/jpc_test/RoomDatabase.kt
+++ b/app/src/main/java/com/ts/jpc_test/RoomDatabase.kt
@@ -6,9 +6,10 @@ import androidx.room.RoomDatabase
 import android.content.Context
 
 
-@Database(entities = [Todo::class, TodoSection::class], version = 17, exportSchema = false)
+@Database(entities = [Todo::class, TodoSection::class], version = 1, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun todoDao(): TodoDao //DAO (Data Access Object) を取得するための抽象メソッド。
+    abstract fun sectionDao(): SectionDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/ts/jpc_test/RoomDatabase.kt
+++ b/app/src/main/java/com/ts/jpc_test/RoomDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.RoomDatabase
 import android.content.Context
 
 
-@Database(entities = [Todo::class], version = 2, exportSchema = false)
+@Database(entities = [Todo::class, TodoSection::class], version = 6, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun todoDao(): TodoDao //DAO (Data Access Object) を取得するための抽象メソッド。
 

--- a/app/src/main/java/com/ts/jpc_test/RoomDatabase.kt
+++ b/app/src/main/java/com/ts/jpc_test/RoomDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.RoomDatabase
 import android.content.Context
 
 
-@Database(entities = [Todo::class, TodoSection::class], version = 6, exportSchema = false)
+@Database(entities = [Todo::class, TodoSection::class], version = 14, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun todoDao(): TodoDao //DAO (Data Access Object) を取得するための抽象メソッド。
 
@@ -31,4 +31,3 @@ abstract class AppDatabase : RoomDatabase() {
         }
     }
 }
-

--- a/app/src/main/java/com/ts/jpc_test/SectionDao.kt
+++ b/app/src/main/java/com/ts/jpc_test/SectionDao.kt
@@ -1,0 +1,26 @@
+package com.ts.jpc_test
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SectionDao {
+    // **TodoSection 用のメソッドを追加**
+    @Query("SELECT COUNT(*) FROM todo_section_table")
+    suspend fun getSectionCount(): Int // セクション数を取得
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSection(todoSection: TodoSection): Long
+
+    @Query("SELECT * FROM todo_section_table WHERE isTodoDeleted = 0 ORDER BY todoSectionNum ASC")
+    fun getAllSections(): Flow<List<TodoSection>> // 削除されたものは表示しない
+
+    @Query("DELETE FROM todo_section_table WHERE todoSectionNum = :sectionNum")
+    suspend fun deleteSection(sectionNum: Int) // @Query で削除処理を記述
+
+    @Query("UPDATE todo_section_table SET isTodoDeleted = 1 WHERE todoSectionNum = :sectionNum")
+    suspend fun logicallyDeleteSection(sectionNum: Int)
+}

--- a/app/src/main/java/com/ts/jpc_test/Todo.kt
+++ b/app/src/main/java/com/ts/jpc_test/Todo.kt
@@ -13,14 +13,14 @@ data class Todo(
     @ColumnInfo(name = "onChecked") val onChecked: Boolean,
     @ColumnInfo(name = "tag") val tag: String,
     @ColumnInfo(name = "quantity") val quantity: Int,
-    @ColumnInfo(name = "onDeleted") val onDeleted: Boolean
+    @ColumnInfo(name = "isDeleted") val onDeleted: Boolean
 )
 
 @Entity(tableName = "todo_section_table")
 data class TodoSection(
     @PrimaryKey(autoGenerate = true) val todoSectionNum: Int = 0,// 自動でIDを増やす
     @ColumnInfo(name = "todoSectionTitle") val todoSectionTitle: String,// 横リストアイテムタイトル
-    @ColumnInfo(name = "todoOnDeleted") val todoOnDeleted: Boolean
+    @ColumnInfo(name = "isTodoDeleted") val todoOnDeleted: Boolean
 )
 
 

--- a/app/src/main/java/com/ts/jpc_test/Todo.kt
+++ b/app/src/main/java/com/ts/jpc_test/Todo.kt
@@ -16,11 +16,5 @@ data class Todo(
     @ColumnInfo(name = "isDeleted") val isDeleted: Boolean
 )
 
-@Entity(tableName = "todoSection")
-data class TodoSection(
-    @PrimaryKey(autoGenerate = true) val todoSectionNum: Int = 0,// 自動でIDを増やす
-    @ColumnInfo(name = "todoSectionTitle") val todoSectionTitle: String,// 横リストアイテムタイトル
-    @ColumnInfo(name = "isTodoDeleted") val todoOnDeleted: Boolean
-)
 
 

--- a/app/src/main/java/com/ts/jpc_test/Todo.kt
+++ b/app/src/main/java/com/ts/jpc_test/Todo.kt
@@ -20,6 +20,7 @@ data class Todo(
 data class TodoSection(
     @PrimaryKey(autoGenerate = true) val todoSectionNum: Int = 0,// 自動でIDを増やす
     @ColumnInfo(name = "todoSectionTitle") val todoSectionTitle: String,// 横リストアイテムタイトル
+    @ColumnInfo(name = "todoOnDeleted") val todoOnDeleted: Boolean
 )
 
 

--- a/app/src/main/java/com/ts/jpc_test/Todo.kt
+++ b/app/src/main/java/com/ts/jpc_test/Todo.kt
@@ -4,7 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "todo_table")
+@Entity(tableName = "todo")
 data class Todo(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,// 自動でIDを増やす
     @ColumnInfo(name = "sectionNum") val sectionNum: Int,
@@ -13,10 +13,10 @@ data class Todo(
     @ColumnInfo(name = "onChecked") val onChecked: Boolean,
     @ColumnInfo(name = "tag") val tag: String,
     @ColumnInfo(name = "quantity") val quantity: Int,
-    @ColumnInfo(name = "isDeleted") val onDeleted: Boolean
+    @ColumnInfo(name = "isDeleted") val isDeleted: Boolean
 )
 
-@Entity(tableName = "todo_section_table")
+@Entity(tableName = "todoSection")
 data class TodoSection(
     @PrimaryKey(autoGenerate = true) val todoSectionNum: Int = 0,// 自動でIDを増やす
     @ColumnInfo(name = "todoSectionTitle") val todoSectionTitle: String,// 横リストアイテムタイトル

--- a/app/src/main/java/com/ts/jpc_test/Todo.kt
+++ b/app/src/main/java/com/ts/jpc_test/Todo.kt
@@ -10,7 +10,7 @@ data class Todo(
     @ColumnInfo(name = "sectionNum") val sectionNum: Int,
     @ColumnInfo(name = "title") val title: String,
     @ColumnInfo(name = "text") val text: String,
-    @ColumnInfo(name = "onChecked") val onChecked: Boolean,
+    @ColumnInfo(name = "onChecked") val isChecked: Boolean,
     @ColumnInfo(name = "tag") val tag: String,
     @ColumnInfo(name = "quantity") val quantity: Int,
     @ColumnInfo(name = "isDeleted") val isDeleted: Boolean

--- a/app/src/main/java/com/ts/jpc_test/Todo.kt
+++ b/app/src/main/java/com/ts/jpc_test/Todo.kt
@@ -7,13 +7,19 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "todo_table")
 data class Todo(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,// 自動でIDを増やす
-    @ColumnInfo(name = "section") val section: String,
+    @ColumnInfo(name = "sectionNum") val sectionNum: Int,
     @ColumnInfo(name = "title") val title: String,
     @ColumnInfo(name = "text") val text: String,
     @ColumnInfo(name = "onChecked") val onChecked: Boolean,
     @ColumnInfo(name = "tag") val tag: String,
     @ColumnInfo(name = "quantity") val quantity: Int,
     @ColumnInfo(name = "onDeleted") val onDeleted: Boolean
+)
+
+@Entity(tableName = "todo_section_table")
+data class TodoSection(
+    @PrimaryKey(autoGenerate = true) val todoSectionNum: Int = 0,// 自動でIDを増やす
+    @ColumnInfo(name = "todoSectionTitle") val todoSectionTitle: String,// 横リストアイテムタイトル
 )
 
 

--- a/app/src/main/java/com/ts/jpc_test/Todo.kt
+++ b/app/src/main/java/com/ts/jpc_test/Todo.kt
@@ -10,9 +10,10 @@ data class Todo(
     @ColumnInfo(name = "section") val section: String,
     @ColumnInfo(name = "title") val title: String,
     @ColumnInfo(name = "text") val text: String,
-    @ColumnInfo(name = "onChecked") val isChecked: Boolean,
+    @ColumnInfo(name = "onChecked") val onChecked: Boolean,
     @ColumnInfo(name = "tag") val tag: String,
-    @ColumnInfo(name = "quantity") val quantity: Int
+    @ColumnInfo(name = "quantity") val quantity: Int,
+    @ColumnInfo(name = "onDeleted") val onDeleted: Boolean
 )
 
 

--- a/app/src/main/java/com/ts/jpc_test/TodoDao.kt
+++ b/app/src/main/java/com/ts/jpc_test/TodoDao.kt
@@ -15,7 +15,7 @@ interface TodoDao {
     suspend fun insert(todo: Todo)// データを新規追加。すでに同じデータがあった場合は上書き
 
     @Update
-    suspend fun update(todo: Todo)
+    suspend fun update(todo: Todo)// 更新
 
     @Delete
     suspend fun delete(todo: Todo)// 特定の ID のタスクを削除

--- a/app/src/main/java/com/ts/jpc_test/TodoDao.kt
+++ b/app/src/main/java/com/ts/jpc_test/TodoDao.kt
@@ -7,18 +7,19 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
+
 // データアクセスオブジェクト（DAO）：Room データベースの操作を定義
 @Dao
 interface TodoDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(todo: Todo)// データを新規追加。すでに同じデータがあった場合は上書き
+    suspend fun insert(todo: Todo) // データを新規追加。すでに同じデータがあった場合は上書き
 
     @Update
-    suspend fun update(todo: Todo)// 更新
+    suspend fun update(todo: Todo) // 更新
 
     @Delete
-    suspend fun delete(todo: Todo)// 特定の ID のタスクを削除
+    suspend fun delete(todo: Todo) // 特定の ID のタスクを削除
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertTodos(todos: List<Todo>) //複数のアイテムをまとめて挿入
@@ -32,22 +33,9 @@ interface TodoDao {
     @Query("SELECT * FROM todo_section_table ORDER BY todoSectionNum ASC")
     suspend fun getAllSectionsNow(): List<TodoSection> // Flow ではなく即時取得
 
-    @Query("SELECT * FROM todo_table WHERE onDeleted = 0 ORDER BY id ASC")
+    @Query("SELECT * FROM todo_table WHERE isDeleted = 0 ORDER BY id ASC")
     fun getActiveTodos(): Flow<List<Todo>> // 削除フラグが立っていないデータのみ取得
 
-    @Query("UPDATE todo_table SET onDeleted = 1 WHERE id = :todoId")
+    @Query("UPDATE todo_table SET isDeleted = 1 WHERE id = :todoId")
     suspend fun markAsDeleted(todoId: Int) // 指定したIDのタスクを論理削除
-
-    // **TodoSection 用のメソッドを追加**
-    @Query("SELECT COUNT(*) FROM todo_section_table")
-    suspend fun getSectionCount(): Int // セクション数を取得
-
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertSection(todoSection: TodoSection): Long
-
-    @Query("SELECT * FROM todo_section_table ORDER BY todoSectionNum ASC")
-    fun getAllSections(): Flow<List<TodoSection>> // すべてのセクションを取得
-
-    @Delete
-    suspend fun deleteSection(todoSection: TodoSection) // 特定のセクションを削除
 }

--- a/app/src/main/java/com/ts/jpc_test/TodoDao.kt
+++ b/app/src/main/java/com/ts/jpc_test/TodoDao.kt
@@ -20,15 +20,24 @@ interface TodoDao {
     @Delete
     suspend fun delete(todo: Todo)// 特定の ID のタスクを削除
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertTodos(todos: List<Todo>) //複数のアイテムをまとめて挿入
+
     @Query("SELECT * FROM todo_table ORDER BY id ASC")
     fun getAll(): Flow<List<Todo>> // すべてのタスクを取得
 
     @Query("SELECT * FROM todo_table WHERE tag = :tag")
     fun getTodosByTag(tag: String): Flow<List<Todo>> //指定されたタグを持つタスクを取得する。
 
+    @Query("SELECT * FROM todo_section_table ORDER BY todoSectionNum ASC")
+    suspend fun getAllSectionsNow(): List<TodoSection> // Flow ではなく即時取得
+
     // **TodoSection 用のメソッドを追加**
+    @Query("SELECT COUNT(*) FROM todo_section_table")
+    suspend fun getSectionCount(): Int // セクション数を取得
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertSection(todoSection: TodoSection) // `TodoSection` を追加
+    suspend fun insertSection(todoSection: TodoSection): Long
 
     @Query("SELECT * FROM todo_section_table ORDER BY todoSectionNum ASC")
     fun getAllSections(): Flow<List<TodoSection>> // すべてのセクションを取得

--- a/app/src/main/java/com/ts/jpc_test/TodoDao.kt
+++ b/app/src/main/java/com/ts/jpc_test/TodoDao.kt
@@ -32,6 +32,12 @@ interface TodoDao {
     @Query("SELECT * FROM todo_section_table ORDER BY todoSectionNum ASC")
     suspend fun getAllSectionsNow(): List<TodoSection> // Flow ではなく即時取得
 
+    @Query("SELECT * FROM todo_table WHERE onDeleted = 0 ORDER BY id ASC")
+    fun getActiveTodos(): Flow<List<Todo>> // 削除フラグが立っていないデータのみ取得
+
+    @Query("UPDATE todo_table SET onDeleted = 1 WHERE id = :todoId")
+    suspend fun markAsDeleted(todoId: Int) // 指定したIDのタスクを論理削除
+
     // **TodoSection 用のメソッドを追加**
     @Query("SELECT COUNT(*) FROM todo_section_table")
     suspend fun getSectionCount(): Int // セクション数を取得

--- a/app/src/main/java/com/ts/jpc_test/TodoDao.kt
+++ b/app/src/main/java/com/ts/jpc_test/TodoDao.kt
@@ -25,4 +25,14 @@ interface TodoDao {
 
     @Query("SELECT * FROM todo_table WHERE tag = :tag")
     fun getTodosByTag(tag: String): Flow<List<Todo>> //指定されたタグを持つタスクを取得する。
+
+    // **TodoSection 用のメソッドを追加**
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSection(todoSection: TodoSection) // `TodoSection` を追加
+
+    @Query("SELECT * FROM todo_section_table ORDER BY todoSectionNum ASC")
+    fun getAllSections(): Flow<List<TodoSection>> // すべてのセクションを取得
+
+    @Delete
+    suspend fun deleteSection(todoSection: TodoSection) // 特定のセクションを削除
 }

--- a/app/src/main/java/com/ts/jpc_test/TodoDao.kt
+++ b/app/src/main/java/com/ts/jpc_test/TodoDao.kt
@@ -24,18 +24,18 @@ interface TodoDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertTodos(todos: List<Todo>) //複数のアイテムをまとめて挿入
 
-    @Query("SELECT * FROM todo_table ORDER BY id ASC")
+    @Query("SELECT * FROM todo ORDER BY id ASC")
     fun getAll(): Flow<List<Todo>> // すべてのタスクを取得
 
-    @Query("SELECT * FROM todo_table WHERE tag = :tag")
+    @Query("SELECT * FROM todo WHERE tag = :tag")
     fun getTodosByTag(tag: String): Flow<List<Todo>> //指定されたタグを持つタスクを取得する。
 
-    @Query("SELECT * FROM todo_section_table ORDER BY todoSectionNum ASC")
+    @Query("SELECT * FROM todoSection ORDER BY todoSectionNum ASC")
     suspend fun getAllSectionsNow(): List<TodoSection> // Flow ではなく即時取得
 
-    @Query("SELECT * FROM todo_table WHERE isDeleted = 0 ORDER BY id ASC")
+    @Query("SELECT * FROM todo WHERE isDeleted = 0 ORDER BY id ASC")
     fun getActiveTodos(): Flow<List<Todo>> // 削除フラグが立っていないデータのみ取得
 
-    @Query("UPDATE todo_table SET isDeleted = 1 WHERE id = :todoId")
+    @Query("UPDATE todo SET isDeleted = 1 WHERE id = :todoId")
     suspend fun markAsDeleted(todoId: Int) // 指定したIDのタスクを論理削除
 }

--- a/app/src/main/java/com/ts/jpc_test/TodoDao.kt
+++ b/app/src/main/java/com/ts/jpc_test/TodoDao.kt
@@ -30,9 +30,6 @@ interface TodoDao {
     @Query("SELECT * FROM todo WHERE tag = :tag")
     fun getTodosByTag(tag: String): Flow<List<Todo>> //指定されたタグを持つタスクを取得する。
 
-    @Query("SELECT * FROM todoSection ORDER BY todoSectionNum ASC")
-    suspend fun getAllSectionsNow(): List<TodoSection> // Flow ではなく即時取得
-
     @Query("SELECT * FROM todo WHERE isDeleted = 0 ORDER BY id ASC")
     fun getActiveTodos(): Flow<List<Todo>> // 削除フラグが立っていないデータのみ取得
 

--- a/app/src/main/java/com/ts/jpc_test/TodoSection.kt
+++ b/app/src/main/java/com/ts/jpc_test/TodoSection.kt
@@ -1,0 +1,12 @@
+package com.ts.jpc_test
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "todoSection")
+data class TodoSection(
+    @PrimaryKey(autoGenerate = true) val todoSectionNum: Int = 0,// 自動でIDを増やす
+    @ColumnInfo(name = "todoSectionTitle") val todoSectionTitle: String,// 横リストアイテムタイトル
+    @ColumnInfo(name = "isTodoDeleted") val todoOnDeleted: Boolean
+)

--- a/app/src/main/java/com/ts/jpc_test/TodoSectionDao.kt
+++ b/app/src/main/java/com/ts/jpc_test/TodoSectionDao.kt
@@ -7,20 +7,20 @@ import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
 
 @Dao
-interface SectionDao {
+interface TodoSectionDao {
     // **TodoSection 用のメソッドを追加**
-    @Query("SELECT COUNT(*) FROM todo_section_table")
+    @Query("SELECT COUNT(*) FROM todoSection")
     suspend fun getSectionCount(): Int // セクション数を取得
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertSection(todoSection: TodoSection): Long
+    suspend fun insert(todoSection: TodoSection): Long
 
-    @Query("SELECT * FROM todo_section_table WHERE isTodoDeleted = 0 ORDER BY todoSectionNum ASC")
+    @Query("SELECT * FROM todoSection WHERE isTodoDeleted = 0 ORDER BY todoSectionNum ASC")
     fun getAllSections(): Flow<List<TodoSection>> // 削除されたものは表示しない
 
-    @Query("DELETE FROM todo_section_table WHERE todoSectionNum = :sectionNum")
+    @Query("DELETE FROM todoSection WHERE todoSectionNum = :sectionNum")
     suspend fun deleteSection(sectionNum: Int) // @Query で削除処理を記述
 
-    @Query("UPDATE todo_section_table SET isTodoDeleted = 1 WHERE todoSectionNum = :sectionNum")
-    suspend fun logicallyDeleteSection(sectionNum: Int)
+    @Query("UPDATE todoSection SET isTodoDeleted = 1 WHERE todoSectionNum = :sectionNum")
+    suspend fun deleteLogicallySection(sectionNum: Int)
 }

--- a/app/src/main/java/com/ts/jpc_test/TodoSectionDao.kt
+++ b/app/src/main/java/com/ts/jpc_test/TodoSectionDao.kt
@@ -23,4 +23,7 @@ interface TodoSectionDao {
 
     @Query("UPDATE todoSection SET isTodoDeleted = 1 WHERE todoSectionNum = :sectionNum")
     suspend fun deleteLogicallySection(sectionNum: Int)
+
+    @Query("SELECT * FROM todoSection ORDER BY todoSectionNum ASC")
+    suspend fun getAllSectionsNow(): List<TodoSection> // Flow ではなく即時取得
 }


### PR DESCRIPTION
## 概要
Roomを使ったデータベースの基本的な構造と管理を学習

## 変更点
deleteボタン、addボタンの中身を作成
削除を論理削除に変更
アイテムとデータベースを紐付け
親セクションのテーブルを追加作成
スクロールの硬直エラーを解消

## 背景・目的
学習

## 影響範囲
新規立ち上げにつき、全体に影響

## 動作確認
Google Pixel 5a

## 参考元
https://www.google.co.jp/url?sa=t&source=web&rct=j&opi=89978449&url=https://zenn.dev/voicy/articles/b8b2e8ae56e98e&ved=2ahUKEwiwzOrJ-ZSMAxXW1TQHHUL5KP8QFnoECBgQAQ&usg=AOvVaw3OD0kcp2Cxii6720uEPIFK
https://developer.android.com/develop/ui/compose/lists?hl=ja

## 追記
https://qiita.com/wcaokaze/items/a066ab81b69578390992
recomposeの最適化について

## 画像
<p align="center">
    <img src="https://github.com/user-attachments/assets/41daa7bf-e4ed-4a89-92a8-7ccd3e76147e" width="30%">
    <img src="https://github.com/user-attachments/assets/7d3edbd7-703c-4aee-8603-d8316bcfc12d" width="30%">
</p>

